### PR TITLE
Add option to share the generated images with LAION

### DIFF
--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -232,7 +232,8 @@ export const useGeneratorStore = defineStore("generator", () => {
             source_processing: sourceProcessing,
             workers: optionsStore.useWorker === "None" ? undefined : [optionsStore.useWorker],
             models: model,
-            r2: true
+            r2: true,
+            shared: useOptionsStore().shareWithLaion === "Enabled"
         })
 
         // Cache parameters so the user can't mutate the output data while it's generating

--- a/src/stores/generator.ts
+++ b/src/stores/generator.ts
@@ -171,8 +171,9 @@ export const useGeneratorStore = defineStore("generator", () => {
 
     const kudosCost = computed(() => {
         const result = Math.pow((params.value.height as number) * (params.value.width as number) - (64*64), 1.75) / Math.pow((1024*1024) - (64*64), 1.75);
-        const kudos_cost = (0.1232 * (params.value.steps as number)) + result * (0.1232 * (params.value.steps as number) * 8.75);
-        return kudos_cost * (params.value.n as number) * (/dpm_2|dpm_2_a|k_heun/.test(params.value.sampler_name as string) ? 2 : 1) * (1 + (postProcessors.value.includes("RealESRGAN_x4plus") ? (0.2 * (1) + 0.3) : 0));
+        const kudos_cost_with_steps = (0.1232 * (params.value.steps as number)) + result * (0.1232 * (params.value.steps as number) * 8.75);
+        const kudos_cost_with_processing_options = kudos_cost_with_steps * (params.value.n as number) * (/dpm_2|dpm_2_a|k_heun/.test(params.value.sampler_name as string) ? 2 : 1) * (1 + (postProcessors.value.includes("RealESRGAN_x4plus") ? (0.2 * (1) + 0.3) : 0));
+        return kudos_cost_with_processing_options + (useOptionsStore().shareWithLaion === "Enabled" ? 1 : 3);
     })
 
     const canGenerate = computed(() => {

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -13,6 +13,7 @@ export const useOptionsStore = defineStore("options", () => {
     }));
     const pageSize = useLocalStorage("pageSize", 25);
     const allowLargerParams = useLocalStorage<IToggle>("allowLargerParams", "Disabled");
+    const shareWithLaion = useLocalStorage<IToggle>("shareWithLaion", "Disabled");
     const autoCarousel = useLocalStorage<IToggle>("autoCarousel", "Enabled");
     //const useCloudflare = useLocalStorage<IToggle>("useCloudflare", "Disabled");
     const useBeta = useLocalStorage<IToggle>("useBeta", "Disabled");
@@ -29,7 +30,7 @@ export const useOptionsStore = defineStore("options", () => {
     const apiKey = useLocalStorage("apikey", "0000000000");
 
     /**
-     * Make your API key anonymous (0000000000) 
+     * Make your API key anonymous (0000000000)
      * */
     function useAnon() {
         apiKey.value = "0000000000";
@@ -44,6 +45,7 @@ export const useOptionsStore = defineStore("options", () => {
         autoCarousel,
         useBeta,
         useWorker,
+        shareWithLaion,
         // Computed
         baseURL,
         // Actions

--- a/src/types/stable_horde.d.ts
+++ b/src/types/stable_horde.d.ts
@@ -37,6 +37,8 @@ export interface GenerationInput {
   source_mask?: string;
   /** If True, the image will be sent via cloudflare r2 download link */
   r2?: boolean;
+  /** If True, The image will be shared with LAION for improving their dataset. This will also reduce your kudos consumption by 2. For anonymous users, this is always True. */
+  shared?: boolean;
 }
 
 export type ModelGenerationInputStable = ModelPayloadRootStable & {

--- a/src/views/OptionsView.vue
+++ b/src/views/OptionsView.vue
@@ -77,6 +77,7 @@ async function handleChange(uploadFile: UploadFile) {
                 </el-form-item>
                 <form-radio  label="Larger Values" prop="allowLargerParams" v-model="store.allowLargerParams" :options="['Enabled', 'Disabled']" info="Allows use of larger step values and dimension sizes if you have the kudos on hand." :disabled="store.apiKey === '0000000000' || store.apiKey === ''" />
                 <form-select label="Use Specific Worker" prop="worker" v-model="store.useWorker" :options="['None', ...workerStore.workers.map(el => {return {label: el.name, value: el.id}})]" />
+                <form-radio  label="Share Generated Images with LAION" prop="shareWithLaion" v-model="store.shareWithLaion" :options="['Enabled', 'Disabled']" info="Automatically and anonymously share images with LAION (the non-profit that created the dataset that was used to train Stable Diffusion) for use in aesthetic training in order to improve future models. See the announcement at https://discord.com/channels/781145214752129095/1020707945694101564/1061980573096226826 for more information. NOTE: This option is automatically enabled for users without a valid API key. " :disabled="store.apiKey === '0000000000' || store.apiKey === ''" />
             </el-tab-pane>
             <el-tab-pane label="📷 Images">
                 <h2>Image Options</h2>


### PR DESCRIPTION
As announced here:
https://discord.com/channels/781145214752129095/1020707945694101564/1061980573096226826

Users can now opt-in to share their generated images with LAION to be part of a dataset for aesthetic labeling, possibly improving future AI image generation tools.